### PR TITLE
Less UI flashing when signing in

### DIFF
--- a/src/components/channels/channels.js
+++ b/src/components/channels/channels.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React from 'react'
 import {Link, NavLink} from 'react-router-dom'
 
 export default function Channels({channels}) {
@@ -20,7 +20,7 @@ export default function Channels({channels}) {
 export const UserChannelsSelect = ({
 	userChannel, userChannels, onChange
 }) => {
-	const [isActive, setIsActive] = useState()
+	// const [isActive, setIsActive] = useState()
 	if (!userChannel || userChannel === null) return null
 
 	/*

--- a/src/components/site/nav.js
+++ b/src/components/site/nav.js
@@ -34,10 +34,12 @@ export default function Nav(props) {
 						<menu>
 							<li>
 								<Link to="/">{RADIO4000_APP_NAME_MINI}</Link>
-								{session ? (
+								{!session && <Link to="/login/">login</Link>}
+
+								{session && (
 									<>
 										<Link to="/account">account</Link>
-										{(session && userChannels?.length) ? (
+										{(userChannels?.length) ? (
 											<>
 												<Link to="/add/">add track</Link>
 												<UserChannelsSelect
@@ -48,13 +50,11 @@ export default function Nav(props) {
 											</>
 										) : null}
 									</>
-								) : (
-									<Link to="/login/">login</Link>
 								)}
 							</li>
 							<li>
 								<Link to="/channels/">channels</Link>
-								{ (!session || !userChannels?.length) && (
+								{ (!session || (!session && !userChannels?.length)) && (
 									<>
 										<Link to="/new/">create</Link>
 										<Link to="/new/import/">import</Link>

--- a/src/hooks/use-session.js
+++ b/src/hooks/use-session.js
@@ -2,15 +2,12 @@ import {useState, useEffect} from 'react'
 import {useNavigate} from 'react-router-dom'
 
 export default function useSession(sessionProvider) {
-	const [session, setSession] = useState(null)
+	const [session, setSession] = useState(sessionProvider.auth.session())
 	const navigate = useNavigate()
 
 	useEffect(() => {
-		setSession(sessionProvider.auth.session())
-
 		sessionProvider.auth.onAuthStateChange((eventName, session) => {
-			/* Handle redirect,
-				 when clicked <email link to reset your password>. */
+			/* Handle redirect, when clicked <email link to reset your password>. */
 			if (eventName === 'PASSWORD_RECOVERY') {
 				navigate('/reset-password/')
 			}

--- a/src/pages/logout.js
+++ b/src/pages/logout.js
@@ -12,6 +12,6 @@ export default function PageLogout({
 			})
 		}
 		navigate('/login', { replace: true })
-	}, [session])
+	}, [session, signOut, navigate])
 	return null
 }

--- a/src/styles/defaults.css
+++ b/src/styles/defaults.css
@@ -68,7 +68,7 @@ p {
 }
 
 small {
-	font-size: 87.5%;
+	font-size: 0.875em;
 }
 
 strong {
@@ -78,7 +78,7 @@ strong {
 /* keyboard shortcuts */
 kbd {
 	display: inline-block;
-	font-size: 0.875rem;
+	font-size: 0.875em;
 	padding: 0 0.4em 0.1em;
 	line-height: initial;
 	background-color: var(--almost-bg);
@@ -107,7 +107,7 @@ label + input:not(:last-child) {
 }
 button,
 input {
-	font-size: 1rem;
+	font-size: 1em;
 	font-family: inherit;
 	color: initial;
 	line-height: 1;

--- a/src/styles/defaults.css
+++ b/src/styles/defaults.css
@@ -170,6 +170,10 @@ select {
 	padding-bottom: 0.2em;
 }
 
+menu select {
+	padding-bottom: 0;
+}
+
 /* line separators */
 hr {
 	margin: 1rem 0;

--- a/src/styles/menu-nav.css
+++ b/src/styles/menu-nav.css
@@ -63,7 +63,7 @@ nav {
 	margin-left: auto;
 }
 .Nav a {
-	min-height: 2rem;
+	min-height: 2em;
 	line-height: 1.8;
 }
 .Nav a:last-of-type {

--- a/src/styles/menu-nav.css
+++ b/src/styles/menu-nav.css
@@ -11,7 +11,7 @@ menu a[aria-current="page"] {
 	font-style: italic;
 	background-color: var(--theme);
 	color: var(--bg-color);
-	text-underline-offset: 0;
+	text-decoration: none;
 }
 menu a:focus [aria-current="page"] {
 	outline: 1px solid var(--link-color);
@@ -23,7 +23,7 @@ menu a {
 
 menu a + a,
 menu select + a {
-	padding: 0.2em;
+	/* padding: 0.2em; */
 	margin: 0.2em;
 }
 menu fieldset {

--- a/src/styles/tracks.css
+++ b/src/styles/tracks.css
@@ -1,13 +1,13 @@
 /* Track */
 .Track {
 	display: flex;
-	font-size: 0.875rem;
+	font-size: 0.875em;
 	border-bottom: 1px solid var(--light);
 }
 .Track-main {
 	flex: 1;
 	align-self: center;
-	padding: 0.4rem;
+	padding: 0.4em;
 }
 .Track.can-edit .Track-main:hover,
 .Track.can-edit .Track-main:focus {


### PR DESCRIPTION
If we set the session as soon as possible it avoids the UI first rendering the un-authed state on load when you're already signed in. Also changed the conditional logic in the menu component to flash a bit less.

See

```
https://github.com/supabase/gotrue-js/pull/30
https://github.com/aicushman/ui/commit/3c4e837342f13e4c6c31feecf1d0a0b0eaf054b7
```