### PR TITLE
Move Firebase stuff from db-session to import page

### DIFF
--- a/src/components/db-session.js
+++ b/src/components/db-session.js
@@ -1,12 +1,9 @@
 import config from 'config'
 import {useState, useEffect} from 'react'
 import {supabase} from 'utils/supabase-client'
-import {firebase} from 'utils/firebase-client'
 import {DbSessionContext} from 'contexts/db-session'
 import useSession from 'hooks/use-session'
-import useSessionFirebase from 'hooks/use-session-firebase'
 import useUserChannels from 'hooks/use-user-channels'
-import useUserChannelFirebase from 'hooks/use-user-channel-firebase'
 
 const {RADIO4000_API_URL} = config
 
@@ -23,16 +20,13 @@ export default function DbSession({children}) {
 			setUserChannel(null)
 		}
 	}, [userChannel])
+
 	useEffect(() => {
 		if (userChannels?.length) {
 			const firstUserChannel = userChannels[0]
 			setUserChannel(firstUserChannel || null)
 		}
 	}, [userChannels])
-
-	const sessionFirebase = useSessionFirebase(firebase)
-	const userFirebase = sessionFirebase?.multiFactor?.user
-	const userChannelFirebase = useUserChannelFirebase(userFirebase?.uid)
 
 	const dbSessionContext = {
 		/* r4 context */
@@ -61,11 +55,6 @@ export default function DbSession({children}) {
 				return database.auth.signIn({email})
 			}
 		},
-
-		/* firebase context (old r4) */
-		firebase,
-		sessionFirebase,
-		userChannelFirebase,
 	}
 
 	return (

--- a/src/components/firebase-ui/auth.js
+++ b/src/components/firebase-ui/auth.js
@@ -1,9 +1,9 @@
 import React from 'react'
 import StyledFirebaseAuth from 'react-firebaseui/StyledFirebaseAuth'
 
-function FirebaseAuth({firebase}) {
+export default function FirebaseAuth({firebase}) {
 	const {auth} = firebase
-	/* firebase-ui-(react) for login flow */
+
 	const firebaseUiConfig = {
 		signInFlow: 'popup',
 		signInOptions: [
@@ -17,11 +17,7 @@ function FirebaseAuth({firebase}) {
 		},
 	}
 
-	return (
-		<StyledFirebaseAuth
+	return <StyledFirebaseAuth
 		uiConfig={firebaseUiConfig}
-		firebaseAuth={auth()}
-		/>
-	)
+		firebaseAuth={auth()} />
 }
-export default FirebaseAuth

--- a/src/hooks/use-session-firebase.js
+++ b/src/hooks/use-session-firebase.js
@@ -2,8 +2,8 @@ import {useState, useEffect} from 'react'
 
 export default function useSessionFirebase(sessionProvider) {
 	const [session, setSession] = useState(null)
-	
-    // Listen to the Firebase Auth state changes 
+
+    // Listen to the Firebase Auth state changes
 	useEffect(() => {
 		const unregisterAuthObserver = sessionProvider.auth()
 			.onAuthStateChanged(async(user) => {
@@ -16,7 +16,7 @@ export default function useSessionFirebase(sessionProvider) {
 						setSession(false)
 					}
 				}
-				setSession(user)
+				setSession(user?.multiFactor?.user)
 			})
 		// Make sure we un-register Firebase observers when the component unmounts.
 		return () => unregisterAuthObserver()

--- a/src/pages/create/channel/import.js
+++ b/src/pages/create/channel/import.js
@@ -1,26 +1,27 @@
 import React, {useState} from 'react'
 import {Link} from 'react-router-dom'
+import ChannelsLayout from 'layouts/channels'
 import FirebaseAuth from 'components/firebase-ui/auth'
 import ErrorDisplay from 'components/error-display'
-import ChannelsLayout from 'layouts/channels'
 import LoginRequired from 'components/login-required'
 
-export default function PageNewChannelImport({
-	dbSession: {
-		radio4000ApiUrl,
-		firebase,
-		session,
-		userChannel,
-		sessionFirebase,
-		userChannelFirebase,
-	},
-}) {
+import {firebase, startFirebase} from 'utils/firebase-client'
+import useSessionFirebase from 'hooks/use-session-firebase'
+import useUserChannelFirebase from 'hooks/use-user-channel-firebase'
+
+// This is not how to do it (?), but we can delay figuring it out until we need Firebase in a second place.
+startFirebase()
+
+export default function PageNewChannelImport({dbSession: {radio4000ApiUrl, session, userChannel}}) {
 	const [loading, setLoading] = useState(false)
 	const [error, setError] = useState(false)
 	const [migrationResult, setMigrationResult] = useState(false)
 
+	const sessionFirebase = useSessionFirebase(firebase)
+	const userChannelFirebase = useUserChannelFirebase(sessionFirebase.uid)
+
 	const tokenSupabase = session?.access_token
-	const tokenFirebase = sessionFirebase?.multiFactor?.user?.accessToken
+	const tokenFirebase = sessionFirebase?.accessToken
 
 	const startMigration = async () => {
 		setLoading(true)

--- a/src/pages/create/channel/import.js
+++ b/src/pages/create/channel/import.js
@@ -18,7 +18,7 @@ export default function PageNewChannelImport({dbSession: {radio4000ApiUrl, sessi
 	const [migrationResult, setMigrationResult] = useState(false)
 
 	const sessionFirebase = useSessionFirebase(firebase)
-	const userChannelFirebase = useUserChannelFirebase(sessionFirebase.uid)
+	const userChannelFirebase = useUserChannelFirebase(sessionFirebase?.uid)
 
 	const tokenSupabase = session?.access_token
 	const tokenFirebase = sessionFirebase?.accessToken

--- a/src/utils/firebase-client.js
+++ b/src/utils/firebase-client.js
@@ -21,12 +21,13 @@ const firebaseConfig = {
 }
 
 /* default firebase app */
-firebase.initializeApp(firebaseConfig)
-
-const dbRef = ref(getDatabase())
+export function startFirebase() {
+	firebase.initializeApp(firebaseConfig)
+}
 
 /* app methods */
 const firebaseGetUser = async (userUid) => {
+	const dbRef = ref(getDatabase())
 	return get(child(dbRef, `users/${userUid}`))
 		.then((snapshot) => {
 			if (snapshot.exists()) {
@@ -39,6 +40,7 @@ const firebaseGetUser = async (userUid) => {
 }
 
 const firebaseGetUserChannel = async (userUid) => {
+	const dbRef = ref(getDatabase())
 	const user = await firebaseGetUser(userUid)
 	const channels = user.channels
 	const channelId = Object.keys(channels)[0]


### PR DESCRIPTION
Moved the _calls_ to the firebase hooks from the `db-session` context to the `import` page.

Moved `firebase.initializeApp()` into a `startFirebase` function. This is to avoid firebase doing stuff on import. The context is maybe nicer, but since we really only need Firebase on /import for now, I prefer it to loading Firebase everywhere. Seems easy enough to import hooks and gogo where we need.