### PR TITLE
Player

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dayjs": "^1.10.7",
         "firebase": "^9.6.5",
         "fuzzysort": "^1.1.4",
-        "radio4000-player": "^0.6.16",
+        "radio4000-player": "^0.6.20",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-firebaseui": "^6.0.0",
@@ -3924,9 +3924,9 @@
       }
     },
     "node_modules/@vimeo/player": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.2.tgz",
-      "integrity": "sha512-7nXMZWyrmomX6eVQr7i4iEpKDpES6hnqR5D3dHNl+WZv8chYfdqCl+zVYUAwSZpbW4oL0C/lGlZW1hrC7fM7iQ==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.3.tgz",
+      "integrity": "sha512-B9WX3dzPvLLhbrqDpHQS1xMUhCZ1iUUvmQubOAp5WBN9RFkNfDC41kv14nYnr0TdSvNV+d6KiG5sDOAbo7tDCg==",
       "dependencies": {
         "native-promise-only": "0.8.1",
         "weakmap-polyfill": "2.0.4"
@@ -12084,9 +12084,9 @@
       }
     },
     "node_modules/radio4000-player": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.16.tgz",
-      "integrity": "sha512-xb48dVXSkISyiMm9r0zWA4WrenRFK6kblEmzTpKXuS6CMMLHwHLtLQTKJ1Av0YBpBAjsP2s48Z2HQrYhw1e34g==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.20.tgz",
+      "integrity": "sha512-QcfdC9PFnjsYbUVcP46VGnxhetxZpnT43JzLC7xyPHPRb8H6cyz5y5Z5bN/YUNT8rvxQFxRCpj2gIbXeyfpmEA==",
       "dependencies": {
         "@vimeo/player": "^2.9.1",
         "document-register-element": "^1.8.1",
@@ -12094,8 +12094,8 @@
         "media-url-parser": "^0.1.3",
         "unfetch": "^4.2.0",
         "vue": "^2.5.16",
-        "vue-custom-element": "^3.2.6",
-        "youtube-player": "^5.5.0"
+        "vue-custom-element": "^3.3.0",
+        "youtube-player": "^5.5.2"
       }
     },
     "node_modules/raf": {
@@ -18039,9 +18039,9 @@
       }
     },
     "@vimeo/player": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.2.tgz",
-      "integrity": "sha512-7nXMZWyrmomX6eVQr7i4iEpKDpES6hnqR5D3dHNl+WZv8chYfdqCl+zVYUAwSZpbW4oL0C/lGlZW1hrC7fM7iQ==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.3.tgz",
+      "integrity": "sha512-B9WX3dzPvLLhbrqDpHQS1xMUhCZ1iUUvmQubOAp5WBN9RFkNfDC41kv14nYnr0TdSvNV+d6KiG5sDOAbo7tDCg==",
       "requires": {
         "native-promise-only": "0.8.1",
         "weakmap-polyfill": "2.0.4"
@@ -23961,9 +23961,9 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "radio4000-player": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.16.tgz",
-      "integrity": "sha512-xb48dVXSkISyiMm9r0zWA4WrenRFK6kblEmzTpKXuS6CMMLHwHLtLQTKJ1Av0YBpBAjsP2s48Z2HQrYhw1e34g==",
+      "version": "0.6.20",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.20.tgz",
+      "integrity": "sha512-QcfdC9PFnjsYbUVcP46VGnxhetxZpnT43JzLC7xyPHPRb8H6cyz5y5Z5bN/YUNT8rvxQFxRCpj2gIbXeyfpmEA==",
       "requires": {
         "@vimeo/player": "^2.9.1",
         "document-register-element": "^1.8.1",
@@ -23971,8 +23971,8 @@
         "media-url-parser": "^0.1.3",
         "unfetch": "^4.2.0",
         "vue": "^2.5.16",
-        "vue-custom-element": "^3.2.6",
-        "youtube-player": "^5.5.0"
+        "vue-custom-element": "^3.3.0",
+        "youtube-player": "^5.5.2"
       }
     },
     "raf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dayjs": "^1.10.7",
         "firebase": "^9.6.5",
         "fuzzysort": "^1.1.4",
+        "radio4000-player": "^0.6.16",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-firebaseui": "^6.0.0",
@@ -3922,6 +3923,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vimeo/player": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.2.tgz",
+      "integrity": "sha512-7nXMZWyrmomX6eVQr7i4iEpKDpES6hnqR5D3dHNl+WZv8chYfdqCl+zVYUAwSZpbW4oL0C/lGlZW1hrC7fM7iQ==",
+      "dependencies": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -6169,6 +6179,12 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/document-register-element": {
+      "version": "1.14.10",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.14.10.tgz",
+      "integrity": "sha512-w5UA37hEIrs+9pruo2yR5UD13c4UHDlkqqjt4qurnp7QsBI9b1IOi8WXUim+aCqKBsENX3Z/cso7XMOuwJH1Yw==",
+      "deprecated": "V0 is gone and the best V1 polyfill is now @ungap/custom-elements"
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
@@ -7054,6 +7070,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/espree": {
@@ -9716,6 +9740,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "node_modules/loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -9886,6 +9915,15 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/media-url-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/media-url-parser/-/media-url-parser-0.1.3.tgz",
+      "integrity": "sha512-47sd2W2cyEgfzNH4iuuxpqDAWGMqk00DC5blkgOUY9rQbVX/OP7/JOX1QEemCnJN8YewKNAiYNmQvjepNwZDNQ==",
+      "dependencies": {
+        "esm": "^3.0.72",
+        "youtube-regex": "^1.0.5"
       }
     },
     "node_modules/memfs": {
@@ -10114,6 +10152,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -12040,6 +12083,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/radio4000-player": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.16.tgz",
+      "integrity": "sha512-xb48dVXSkISyiMm9r0zWA4WrenRFK6kblEmzTpKXuS6CMMLHwHLtLQTKJ1Av0YBpBAjsP2s48Z2HQrYhw1e34g==",
+      "dependencies": {
+        "@vimeo/player": "^2.9.1",
+        "document-register-element": "^1.8.1",
+        "lodash.debounce": "^4.0.8",
+        "media-url-parser": "^0.1.3",
+        "unfetch": "^4.2.0",
+        "vue": "^2.5.16",
+        "vue-custom-element": "^3.2.6",
+        "youtube-player": "^5.5.0"
+      }
+    },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -13008,6 +13066,11 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
+    },
+    "node_modules/sister": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -13986,6 +14049,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -14157,6 +14225,20 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vue": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+    },
+    "node_modules/vue-custom-element": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vue-custom-element/-/vue-custom-element-3.3.0.tgz",
+      "integrity": "sha512-ePuy1EDDJd9/piwXLwsCyMQ964HsdhXPzypM9OX0r4JBa20EVN28U7RXeTWwXkoFKim/b3sP7xT2NEM0Di6tUQ==",
+      "engines": {
+        "node": ">= 4.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -14202,6 +14284,14 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/weakmap-polyfill": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
+      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/web-vitals": {
@@ -15093,6 +15183,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "dependencies": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      }
+    },
+    "node_modules/youtube-player/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/youtube-player/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/youtube-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/youtube-regex/-/youtube-regex-1.0.5.tgz",
+      "integrity": "sha1-Xyf6yrC31m0B7rx6/Jpqac9hq9g=",
+      "engines": {
+        "node": ">= 0.10.33",
+        "npm": ">= 1.4.28"
       }
     }
   },
@@ -17916,6 +18038,15 @@
         "eslint-visitor-keys": "^3.0.0"
       }
     },
+    "@vimeo/player": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.16.2.tgz",
+      "integrity": "sha512-7nXMZWyrmomX6eVQr7i4iEpKDpES6hnqR5D3dHNl+WZv8chYfdqCl+zVYUAwSZpbW4oL0C/lGlZW1hrC7fM7iQ==",
+      "requires": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -19622,6 +19753,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "document-register-element": {
+      "version": "1.14.10",
+      "resolved": "https://registry.npmjs.org/document-register-element/-/document-register-element-1.14.10.tgz",
+      "integrity": "sha512-w5UA37hEIrs+9pruo2yR5UD13c4UHDlkqqjt4qurnp7QsBI9b1IOi8WXUim+aCqKBsENX3Z/cso7XMOuwJH1Yw=="
+    },
     "dom-accessibility-api": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
@@ -20282,6 +20418,11 @@
         "normalize-path": "^3.0.0",
         "schema-utils": "^3.1.1"
       }
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
     },
     "espree": {
       "version": "9.3.0",
@@ -22232,6 +22373,11 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "load-script": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/load-script/-/load-script-1.0.0.tgz",
+      "integrity": "sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ="
+    },
     "loader-runner": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
@@ -22369,6 +22515,15 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "media-url-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/media-url-parser/-/media-url-parser-0.1.3.tgz",
+      "integrity": "sha512-47sd2W2cyEgfzNH4iuuxpqDAWGMqk00DC5blkgOUY9rQbVX/OP7/JOX1QEemCnJN8YewKNAiYNmQvjepNwZDNQ==",
+      "requires": {
+        "esm": "^3.0.72",
+        "youtube-regex": "^1.0.5"
+      }
     },
     "memfs": {
       "version": "3.4.1",
@@ -22529,6 +22684,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -23800,6 +23960,21 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "radio4000-player": {
+      "version": "0.6.16",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.16.tgz",
+      "integrity": "sha512-xb48dVXSkISyiMm9r0zWA4WrenRFK6kblEmzTpKXuS6CMMLHwHLtLQTKJ1Av0YBpBAjsP2s48Z2HQrYhw1e34g==",
+      "requires": {
+        "@vimeo/player": "^2.9.1",
+        "document-register-element": "^1.8.1",
+        "lodash.debounce": "^4.0.8",
+        "media-url-parser": "^0.1.3",
+        "unfetch": "^4.2.0",
+        "vue": "^2.5.16",
+        "vue-custom-element": "^3.2.6",
+        "youtube-player": "^5.5.0"
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -24536,6 +24711,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.6.tgz",
       "integrity": "sha512-sDl4qMFpijcGw22U5w63KmD3cZJfBuFlVNbVMKje2keoKML7X2UzWbc4XrmEbDwg0NXJc3yv4/ox7b+JWb57kQ=="
     },
+    "sister": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sister/-/sister-3.0.2.tgz",
+      "integrity": "sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA=="
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -25269,6 +25449,11 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "unfetch": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
+      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
+    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
@@ -25395,6 +25580,16 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vue": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+    },
+    "vue-custom-element": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vue-custom-element/-/vue-custom-element-3.3.0.tgz",
+      "integrity": "sha512-ePuy1EDDJd9/piwXLwsCyMQ964HsdhXPzypM9OX0r4JBa20EVN28U7RXeTWwXkoFKim/b3sP7xT2NEM0Di6tUQ=="
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -25435,6 +25630,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "weakmap-polyfill": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
+      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw=="
     },
     "web-vitals": {
       "version": "2.1.4",
@@ -26136,6 +26336,36 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+    },
+    "youtube-player": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/youtube-player/-/youtube-player-5.5.2.tgz",
+      "integrity": "sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==",
+      "requires": {
+        "debug": "^2.6.6",
+        "load-script": "^1.0.0",
+        "sister": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "youtube-regex": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/youtube-regex/-/youtube-regex-1.0.5.tgz",
+      "integrity": "sha1-Xyf6yrC31m0B7rx6/Jpqac9hq9g="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dayjs": "^1.10.7",
         "firebase": "^9.6.5",
         "fuzzysort": "^1.1.4",
-        "radio4000-player": "^0.6.20",
+        "radio4000-player": "^0.6.24",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-firebaseui": "^6.0.0",
@@ -12084,9 +12084,9 @@
       }
     },
     "node_modules/radio4000-player": {
-      "version": "0.6.20",
-      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.20.tgz",
-      "integrity": "sha512-QcfdC9PFnjsYbUVcP46VGnxhetxZpnT43JzLC7xyPHPRb8H6cyz5y5Z5bN/YUNT8rvxQFxRCpj2gIbXeyfpmEA==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.24.tgz",
+      "integrity": "sha512-G6vTgWLSy/Bo1P112IcMN8sljvCmo6seNskN2eNVrigirO17Wt4VnWgmaUQo48gfwe8ZHXcyShrrOCd19Qsycg==",
       "dependencies": {
         "@vimeo/player": "^2.9.1",
         "document-register-element": "^1.8.1",
@@ -23961,9 +23961,9 @@
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
     "radio4000-player": {
-      "version": "0.6.20",
-      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.20.tgz",
-      "integrity": "sha512-QcfdC9PFnjsYbUVcP46VGnxhetxZpnT43JzLC7xyPHPRb8H6cyz5y5Z5bN/YUNT8rvxQFxRCpj2gIbXeyfpmEA==",
+      "version": "0.6.24",
+      "resolved": "https://registry.npmjs.org/radio4000-player/-/radio4000-player-0.6.24.tgz",
+      "integrity": "sha512-G6vTgWLSy/Bo1P112IcMN8sljvCmo6seNskN2eNVrigirO17Wt4VnWgmaUQo48gfwe8ZHXcyShrrOCd19Qsycg==",
       "requires": {
         "@vimeo/player": "^2.9.1",
         "document-register-element": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dayjs": "^1.10.7",
     "firebase": "^9.6.5",
     "fuzzysort": "^1.1.4",
+    "radio4000-player": "^0.6.16",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebaseui": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dayjs": "^1.10.7",
     "firebase": "^9.6.5",
     "fuzzysort": "^1.1.4",
-    "radio4000-player": "^0.6.16",
+    "radio4000-player": "^0.6.20",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebaseui": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dayjs": "^1.10.7",
     "firebase": "^9.6.5",
     "fuzzysort": "^1.1.4",
-    "radio4000-player": "^0.6.20",
+    "radio4000-player": "^0.6.24",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-firebaseui": "^6.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ export default function App() {
 				<DbSession>
 					<DbSessionContext.Consumer>
 						{(dbSession) => (
-							<Layout session={dbSession.session}>
+							<Layout dbSession={dbSession} session={dbSession.session}>
 								<Routes>
 									<Route path="/" element={<PageHome dbSession={dbSession} />} />
 
@@ -51,6 +51,7 @@ export default function App() {
 											<PageAccount dbSession={dbSession} />
 										</AuthRequired>
 									}></Route>
+
 									{/* Channel(s) */}
 									<Route path="create/channel/import" element={<PageChannelsImport dbSession={dbSession} />} />
 									<Route path="channels/me" element={

--- a/src/components/channels/channels.js
+++ b/src/components/channels/channels.js
@@ -1,14 +1,22 @@
+import {usePlayer} from 'contexts/player'
 import React from 'react'
 import {Link} from 'react-router-dom'
 
 export default function Channels({channels}) {
+	const player = usePlayer()
+
 	return channels ? (
 		<ul>
 			{channels.map((channel) => (
 				<li key={channel.id}>
+					<button type="button" onClick={() => player.setChannel(channel)}>
+						▶
+					</button>
 					<Link to={`/${channel.slug}/`}>{channel.name}</Link>
 				</li>
 			))}
 		</ul>
-	) : <p>No channelsi ??</p>
+	) : (
+		<p>No channelsi ??</p>
+	)
 }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -2,7 +2,7 @@ import 'radio4000-player'
 import {usePlayer} from 'contexts/player'
 
 export default function Player() {
-	const {channel, track} = usePlayer()
+	const {channel} = usePlayer()
 
 	return (
 		<div className="Player">

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -2,18 +2,20 @@ import 'radio4000-player'
 import {usePlayer} from 'contexts/player'
 
 export default function Player() {
+	const {channel, track} = usePlayer()
+
 	return (
 		<div className="Player">
 			<Statusline />
-			{/* <radio4000-player
-				ref={playerEl}
+			<radio4000-player
+				// channel-slug="oskar"
+				channel-slug={channel?.slug}
 				// autoplay="true"
 				// volume="0"
-				// channel-slug="oskar"
-				showHeader="true"
-				showControls="true"
-				showTrackList="true"
-			></radio4000-player> */}
+				show-header="false"
+				show-controls="false"
+				show-tracklist="true"
+			></radio4000-player>
 		</div>
 	)
 }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,0 +1,58 @@
+import 'radio4000-player'
+import {usePlayer} from 'contexts/player'
+
+export default function Player() {
+	return (
+		<div className="Player">
+			<Statusline />
+			{/* <radio4000-player
+				ref={playerEl}
+				// autoplay="true"
+				// volume="0"
+				// channel-slug="oskar"
+				showHeader="true"
+				showControls="true"
+				showTrackList="true"
+			></radio4000-player> */}
+		</div>
+	)
+}
+
+function Statusline() {
+	const {channel, track} = usePlayer()
+	return (
+		<div className="Statusline">
+			{channel && channel.name} | {track && track.title}
+		</div>
+	)
+}
+
+// Non-working attempt to set a playlist
+// import {useRef} from 'react'
+// const playerEl = useRef()
+// useEffect(() => {
+// 	if (playerEl.current) {
+// 		console.log(playerEl.current)
+// 		var vue = playerEl.getVueInstance()
+// 		vue.updatePlaylist(testPlaylist)
+// 	}
+// }, [playerEl])
+
+// Create a playlist.
+// const testPlaylist = {
+// 	title: 'A title for this list',
+// 	image:
+// 		'https://78.media.tumblr.com/5080191d7d19fe64da558f2b4324563e/tumblr_p8eoiltn1t1twkjb3o1_1280.png',
+// 	tracks: [
+// 		{
+// 			id: '1',
+// 			title: 'Randomfunk.ogg',
+// 			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_01_-_Randomfunk.ogg',
+// 		},
+// 		{
+// 			id: '2',
+// 			title: 'Rare and Cheese - Jazzpolice',
+// 			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_02_-_Jazzpolice.ogg',
+// 		},
+// 	],
+// }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,14 +1,16 @@
 import 'radio4000-player'
-import {usePlayer} from 'contexts/player'
 import {useRef, useEffect} from 'react'
+import {usePlayer} from 'contexts/player'
+import useTracks from 'hooks/use-tracks'
 
-export default function Player() {
+export default function Player({database}) {
 	const {channel} = usePlayer()
 	const playerEl = useRef(null)
+	const {data: tracks} = useTracks(channel?.id, database)
 
-	if (channel && playerEl.current) {
-		var vue = playerEl.current.getVueInstance()
-		vue.updatePlaylist(testPlaylist)
+	if (tracks?.length) {
+		const vue = playerEl.current.getVueInstance()
+		vue.updatePlaylist(buildPlaylist(channel, tracks))
 	}
 
 	return (
@@ -36,22 +38,9 @@ function Statusline() {
 	)
 }
 
-// Create a playlist.
-
-const testPlaylist = {
-	title: 'A title for this list',
-	image:
-		'https://78.media.tumblr.com/5080191d7d19fe64da558f2b4324563e/tumblr_p8eoiltn1t1twkjb3o1_1280.png',
-	tracks: [
-		{
-			id: '1',
-			title: 'Randomfunk.ogg',
-			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_01_-_Randomfunk.ogg',
-		},
-		{
-			id: '2',
-			title: 'Rare and Cheese - Jazzpolice',
-			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_02_-_Jazzpolice.ogg',
-		},
-	],
+function buildPlaylist(channel, tracks) {
+	return {
+		title: channel.title,
+		tracks,
+	}
 }

--- a/src/components/player.js
+++ b/src/components/player.js
@@ -1,15 +1,22 @@
 import 'radio4000-player'
 import {usePlayer} from 'contexts/player'
+import {useRef, useEffect} from 'react'
 
 export default function Player() {
 	const {channel} = usePlayer()
+	const playerEl = useRef(null)
+
+	if (channel && playerEl.current) {
+		var vue = playerEl.current.getVueInstance()
+		vue.updatePlaylist(testPlaylist)
+	}
 
 	return (
 		<div className="Player">
 			<Statusline />
 			<radio4000-player
-				// channel-slug="oskar"
-				channel-slug={channel?.slug}
+				ref={playerEl}
+				// channel-slug={channel?.slug}
 				// autoplay="true"
 				// volume="0"
 				show-header="false"
@@ -29,32 +36,22 @@ function Statusline() {
 	)
 }
 
-// Non-working attempt to set a playlist
-// import {useRef} from 'react'
-// const playerEl = useRef()
-// useEffect(() => {
-// 	if (playerEl.current) {
-// 		console.log(playerEl.current)
-// 		var vue = playerEl.getVueInstance()
-// 		vue.updatePlaylist(testPlaylist)
-// 	}
-// }, [playerEl])
-
 // Create a playlist.
-// const testPlaylist = {
-// 	title: 'A title for this list',
-// 	image:
-// 		'https://78.media.tumblr.com/5080191d7d19fe64da558f2b4324563e/tumblr_p8eoiltn1t1twkjb3o1_1280.png',
-// 	tracks: [
-// 		{
-// 			id: '1',
-// 			title: 'Randomfunk.ogg',
-// 			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_01_-_Randomfunk.ogg',
-// 		},
-// 		{
-// 			id: '2',
-// 			title: 'Rare and Cheese - Jazzpolice',
-// 			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_02_-_Jazzpolice.ogg',
-// 		},
-// 	],
-// }
+
+const testPlaylist = {
+	title: 'A title for this list',
+	image:
+		'https://78.media.tumblr.com/5080191d7d19fe64da558f2b4324563e/tumblr_p8eoiltn1t1twkjb3o1_1280.png',
+	tracks: [
+		{
+			id: '1',
+			title: 'Randomfunk.ogg',
+			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_01_-_Randomfunk.ogg',
+		},
+		{
+			id: '2',
+			title: 'Rare and Cheese - Jazzpolice',
+			url: 'https://ia801409.us.archive.org/5/items/DWK051/Rare_and_Cheese_-_02_-_Jazzpolice.ogg',
+		},
+	],
+}

--- a/src/components/tracks/tracks.js
+++ b/src/components/tracks/tracks.js
@@ -1,18 +1,22 @@
+import {usePlayer} from 'contexts/player'
 import Track from './track'
 
 export default function Tracks({database, tracks, canEdit, afterDelete}) {
+	const player = usePlayer()
 	if (!tracks?.length) return <p>No tracks</p>
 
 	return (
 		<section className="Tracks">
 			{tracks.map((track) => (
-				<Track
-					key={track.id}
-					database={database}
-					track={track}
-					canEdit={canEdit}
-					afterDelete={afterDelete}
-				></Track>
+				<div key={track.id}>
+					<button type="button" onClick={() => player.setTrack(track)}>▶</button>
+					<Track
+						database={database}
+						track={track}
+						canEdit={canEdit}
+						afterDelete={afterDelete}
+					></Track>
+				</div>
 			))}
 		</section>
 	)

--- a/src/contexts/player.js
+++ b/src/contexts/player.js
@@ -1,0 +1,18 @@
+const {createContext, useContext, useState} = require('react')
+
+const PlayerContext = createContext()
+
+function PlayerProvider(props) {
+	const [channel, setChannel] = useState()
+	const [track, setTrack] = useState()
+	const value = {channel, setChannel, track, setTrack}
+	return <PlayerContext.Provider value={value}>{props.children}</PlayerContext.Provider>
+}
+
+function usePlayer() {
+	const context = useContext(PlayerContext)
+	if (context === undefined) throw new Error('usePlayer must be used within a PlayerProvider')
+	return context
+}
+
+export {PlayerProvider, usePlayer}

--- a/src/hooks/use-tracks.js
+++ b/src/hooks/use-tracks.js
@@ -21,7 +21,7 @@ export default function useTracks(channelId, database) {
 				console.log('Error fetching tracks', error)
 			}
 		}
-		fetchData()
+		if (channelId) fetchData()
 	}, [channelId, database])
 
 	return {data: tracks, error, setTracks}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 @import url("./styles/variables.css");
 @import url("./styles/defaults.css");
 @import url("./styles/layout-themes.css");
+@import url("./styles/player.css");
 
 /* utility components */
 @import url("./styles/menu-nav.css");

--- a/src/layouts/app.js
+++ b/src/layouts/app.js
@@ -1,6 +1,8 @@
 import {useState, useEffect} from 'react'
 import {ThemeContext, themeContextDefault, darkMediaQuery} from 'contexts/theme.js'
+import {PlayerProvider} from 'contexts/player'
 import SiteNav from 'components/site/nav'
+import Player from 'components/player'
 
 export default function LayoutApp({children, session}) {
 	const [theme, setTheme] = useState(themeContextDefault.theme)
@@ -27,7 +29,7 @@ export default function LayoutApp({children, session}) {
 		setTheme(newTheme)
 	}
 
-		const themeContext = {
+	const themeContext = {
 		theme,
 		themes: themeContextDefault.themes,
 		toggleTheme: toggleTheme
@@ -35,14 +37,17 @@ export default function LayoutApp({children, session}) {
 
 	return (
 		<ThemeContext.Provider value={themeContext}>
-			<main className={`Layout Layout--theme-${theme}`}>
-				<header className="Layout-header">
-					<SiteNav/>
-				</header>
-				<main className="Layout-main">
-					{children}
+			<PlayerProvider>
+				<main className={`Layout Layout--theme-${theme}`}>
+					<header className="Layout-header">
+						<SiteNav />
+					</header>
+					<main className="Layout-main">{children}</main>
+					<footer className="Layout-footer">
+						<Player />
+					</footer>
 				</main>
-			</main>
+			</PlayerProvider>
 		</ThemeContext.Provider>
 	)
 }

--- a/src/layouts/app.js
+++ b/src/layouts/app.js
@@ -4,7 +4,7 @@ import {PlayerProvider} from 'contexts/player'
 import SiteNav from 'components/site/nav'
 import Player from 'components/player'
 
-export default function LayoutApp({children, session}) {
+export default function LayoutApp({children, dbSession, session}) {
 	const [theme, setTheme] = useState(themeContextDefault.theme)
 
 	const darkModeListener = (event) => {
@@ -44,7 +44,7 @@ export default function LayoutApp({children, session}) {
 					</header>
 					<main className="Layout-main">{children}</main>
 					<footer className="Layout-footer">
-						<Player />
+						<Player database={dbSession.database} />
 					</footer>
 				</main>
 			</PlayerProvider>

--- a/src/styles/layout-themes.css
+++ b/src/styles/layout-themes.css
@@ -67,3 +67,14 @@ html,
 .Layout-main section {
 	margin-bottom: 1.5em;
 }
+
+.Layout-footer {
+	margin-top: auto;
+	position: fixed;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	z-index: 1;
+	border-top: 1px solid var(--darkgray);
+	background: var(--bg-color);
+}

--- a/src/styles/layout-themes.css
+++ b/src/styles/layout-themes.css
@@ -78,3 +78,4 @@ html,
 	border-top: 1px solid var(--darkgray);
 	background: var(--bg-color);
 }
+

--- a/src/styles/layout-themes.css
+++ b/src/styles/layout-themes.css
@@ -70,11 +70,11 @@ html,
 
 .Layout-footer {
 	margin-top: auto;
-	position: fixed;
-	bottom: 0;
-	left: 0;
-	right: 0;
-	z-index: 1;
+	/* position: fixed; */
+	/* bottom: 0; */
+	/* left: 0; */
+	/* right: 0; */
+	/* z-index: 1; */
 	border-top: 1px solid var(--darkgray);
 	background: var(--bg-color);
 }

--- a/src/styles/player.css
+++ b/src/styles/player.css
@@ -1,0 +1,14 @@
+/* This is stupid but .Layout naming conflict */
+
+.Player radio4000-player {
+	max-height: 200px;
+}
+
+radio4000-player .Layout {
+	padding: 0;
+}
+
+radio4000-player .Layout-footer {
+	position: initial;
+	border-top: none;
+}

--- a/src/styles/tracks.css
+++ b/src/styles/tracks.css
@@ -2,6 +2,7 @@
 .Track {
 	position: relative;
 	display: flex;
+	flex: 1;
 	font-size: 0.875em;
 	border-bottom: 1px solid var(--lightgray);
 }
@@ -55,4 +56,9 @@
 }
 .Layout--theme-dark .Track.is-editing {
 	background: var(--almost-bg);
+}
+
+.Tracks > * {
+	display: flex;
+	flex: 1;
 }


### PR DESCRIPTION
Adds a new `usePlayer()` hook that can be used anywhere. Currently it can hold and set a `channel` and a `track` but that's mostly for testing. The hook uses context behind the scenes ala https://kentcdodds.com/blog/how-to-use-react-context-effectively. Like this:

https://github.com/radio4000/cms/blob/aa1396564888dc416ae47f7e4f876c6a6d56504a/src/components/player.js#L21-L28

Also adds the `<radio4000-player>` and renders it into the layout footer for now. Made it sticky as well. Since the player loads data from Firebase we need to consider what to do when data doesn't come from firebase. The `setPlaylist` method? But couldn't make it work yet..

- [x] Make `<radio4000-player>.setPlaylist()` work see https://github.com/radio4000/cms/blob/feat/player/src/components/player.js#L30
- [x] Fix https://github.com/internet4000/radio4000-player/issues/168

Closes #21 